### PR TITLE
Add be_uri alias for is_uri

### DIFF
--- a/lib/wildcard_matchers/matchers/is_uri.rb
+++ b/lib/wildcard_matchers/matchers/is_uri.rb
@@ -5,6 +5,7 @@ module WildcardMatchers
     def is_uri(hash = {})
       IsUri.new(hash)
     end
+    alias_method :be_uri, :is_uri
 
     class IsUri < ::WildcardMatchers::WildcardMatcher
       protected

--- a/spec/wildcard_matchers/matchers/is_uri_spec.rb
+++ b/spec/wildcard_matchers/matchers/is_uri_spec.rb
@@ -4,6 +4,7 @@ describe WildcardMatchers::Matchers::IsUri do
   [ [ "http://example.com", :is_uri ],
     [ "http://example.com", :is_uri, :scheme => "http", :host => "example.com" ],
     [ "http://example.com", :is_uri, :host => /example/ ],
+    [ "http://example.com", :be_uri ]
   ].each do |actual, matcher, *args|
     it_behaves_like "wildcard match", actual, matcher, *args
   end


### PR DESCRIPTION
be_uri alias is useful for RSpec.
`expect(current_url).to be_uri(host: some_host, path: some_path)` is
more English-like than
`expect(current_url).to is_uri(host: some_host, path: some_path)`